### PR TITLE
Fix styleguidist

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "postcss-loader": "2.0.7",
     "react-docgen-typescript": "1.2.2",
     "react-scripts-ts": "2.8.0",
-    "react-styleguidist": "6.1.0",
+    "react-styleguidist": "6.0.33",
     "react-test-renderer": "15.5.4",
     "style-loader": "0.19.0",
     "ts-jest": "20.0.14",


### PR DESCRIPTION
The newer version of react-styleguidist has a bug (unpinned sub dependency), so have had to roll back the version we are using for now.