### PR TITLE
Fix safari collapse fade bug

### DIFF
--- a/src/ts/components/collapse.tsx
+++ b/src/ts/components/collapse.tsx
@@ -1,15 +1,14 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import { PureComponent } from 'react';
-import { TRANSPARENT_WHITE } from '../constants';
 import { ComponentProps } from '../types';
 
 const ENOUGH_TIME_FOR_RERENDER = 50;
 const DEFAULT_HEIGHT = 0;
 const DEFAULT_DURATION = 200;
 const DEFAULT_FADE_HEIGHT = 50;
-const DEFAULT_TRANSPARENT_COLOR = TRANSPARENT_WHITE;
-const DEFAULT_FADE_COLOR = '#FFF';
+const DEFAULT_TRANSPARENT_COLOR = 'rgba(255, 255, 255, 0)';
+const DEFAULT_FADE_COLOR = 'rgba(255, 255, 255, 1)';
 
 export interface CollapseProps
   extends ComponentProps,
@@ -36,11 +35,11 @@ export interface CollapseProps
   fadeOut?: boolean;
   /**
    * Color to fade to
-   * @default white
+   * @default rgba(255, 255, 255, 1)
    */
   fadeColor?: string;
   /**
-   * Transparent color to fade from
+   * Transparent color to fade from (this should be a transparent version of the fadeColor)
    * @default rgba(255, 255, 255, 0)
    */
   transparentColor?: string;

--- a/src/ts/constants.ts
+++ b/src/ts/constants.ts
@@ -7,6 +7,3 @@ export const MATCHES_BLANK_LAST_LINE = /\n\s*$/;
 export const MATCHES_AMPERSAND = /&/g;
 export const MATCHES_NON_WORD_CHARACTERS = /[\W_]+/gi;
 export const MATCHES_LEADING_AND_TRAILING_HYPHENS = /(^-+|-+$)/g;
-
-export const TRANSPARENT_WHITE = 'rgba(255, 255, 255, 0)';
-export const TRANSPARENT_BLACK = 'rgba(0, 0, 0, 0)';

--- a/tests/__snapshots__/collapse.tsx.snap
+++ b/tests/__snapshots__/collapse.tsx.snap
@@ -98,7 +98,7 @@ exports[`Collapse should close to custom height 2`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 0,
@@ -133,7 +133,7 @@ exports[`Collapse should close to custom height 3`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -168,7 +168,7 @@ exports[`Collapse should close to custom height 4`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -221,7 +221,7 @@ exports[`Collapse should close to default height 2`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 0,
@@ -255,7 +255,7 @@ exports[`Collapse should close to default height 3`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -289,7 +289,7 @@ exports[`Collapse should close to default height 4`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -390,7 +390,7 @@ exports[`Collapse should match snapshot with fade out 1`] = `
     className="collapse-fade"
     style={
       Object {
-        "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+        "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
         "bottom": 0,
         "height": 50,
         "opacity": 1,
@@ -424,7 +424,7 @@ exports[`Collapse should open from custom height 1`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -459,7 +459,7 @@ exports[`Collapse should open from custom height 2`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -494,7 +494,7 @@ exports[`Collapse should open from custom height 3`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 0,
@@ -548,7 +548,7 @@ exports[`Collapse should open from default height 1`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -582,7 +582,7 @@ exports[`Collapse should open from default height 2`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 1,
@@ -616,7 +616,7 @@ exports[`Collapse should open from default height 3`] = `
       className="collapse-fade"
       style={
         Object {
-          "background": "linear-gradient(rgba(255, 255, 255, 0), #FFF 80%)",
+          "background": "linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%)",
           "bottom": 0,
           "height": 50,
           "opacity": 0,

--- a/tests/collapse.tsx
+++ b/tests/collapse.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
 import { Collapse } from '../src/ts/';
-import { TRANSPARENT_BLACK } from '../src/ts/constants';
 
 describe('Collapse', () => {
   const createNodeMock = () => ({
@@ -65,7 +64,7 @@ describe('Collapse', () => {
         fadeOut
         fadeColor="red"
         fadeHeight={10}
-        transparentColor={TRANSPARENT_BLACK}
+        transparentColor="rgba(0, 0, 0, 0)"
       />
     );
 


### PR DESCRIPTION
Fix bug in safari with the collapse component where it treated `transparent` as black with zero opacity rather than white resulting in a strange fade with the default fade out color (see below).

Before:
![screen shot 2018-04-04 at 14 38 40](https://user-images.githubusercontent.com/6729372/38311338-db6761b4-3816-11e8-9ef9-98cca4b1cee0.png)
After:
![screen shot 2018-04-04 at 14 38 09](https://user-images.githubusercontent.com/6729372/38311350-e7c53602-3816-11e8-8009-2ae37b96466f.png)
