### PR TITLE
Upgrade node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 
 language: node_js
 
-node_js:
-  - 8.11.2
-
 install:
   - npm install
 


### PR DESCRIPTION
Travis can now load the node version from a `.npmrc` if the `node_js` version is not set in the config: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions-using-.nvmrc