### PR TITLE
Only set overflow to hidden if not opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/ts/components/misc/collapse.tsx
+++ b/src/ts/components/misc/collapse.tsx
@@ -151,7 +151,7 @@ export class Collapse extends PureComponent<CollapseProps, CollapseState> {
       minHeight,
       maxHeight: opened ? null : height,
       position: 'relative' as 'relative',
-      overflow: 'hidden' as 'hidden',
+      overflow: (!opened ? 'hidden' : 'initial') as 'hidden' | 'initial',
       transition: `ease-in-out ${animationDuration}ms max-height`,
     };
 

--- a/tests/__snapshots__/collapse.tsx.snap
+++ b/tests/__snapshots__/collapse.tsx.snap
@@ -72,7 +72,7 @@ exports[`Collapse should close to custom height 1`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "hidden",
+        "overflow": "initial",
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }
@@ -200,7 +200,7 @@ exports[`Collapse should close to default height 1`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "hidden",
+        "overflow": "initial",
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }
@@ -336,7 +336,7 @@ exports[`Collapse should match snapshot when expanded 1`] = `
     Object {
       "maxHeight": null,
       "minHeight": null,
-      "overflow": "hidden",
+      "overflow": "initial",
       "position": "relative",
       "transition": "ease-in-out 200ms max-height",
     }
@@ -554,7 +554,7 @@ exports[`Collapse should open from custom height 4`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "hidden",
+        "overflow": "initial",
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }
@@ -679,7 +679,7 @@ exports[`Collapse should open from default height 4`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "hidden",
+        "overflow": "initial",
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }


### PR DESCRIPTION
We've got a problem on novo whereby when the roe `<Collapse />` is opened it is still hiding all overflow - this clips some components like `react-datepicker` which use absolute positioning and ends up being displayed outside of the collapse.

This fix sets the overflow to hidden only if the collapse is not open or opening.

|Problem|After PR|
|-|-|
|<img width="533" alt="image" src="https://user-images.githubusercontent.com/16224413/53947785-5bd28d00-40be-11e9-9c3f-21b8f9a4aa13.png">|<img width="537" alt="image" src="https://user-images.githubusercontent.com/16224413/53947751-48bfbd00-40be-11e9-866e-d02fe2868100.png">|