### PR TITLE
Set overflow to null instead of initial to support IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/ts/components/misc/collapse.tsx
+++ b/src/ts/components/misc/collapse.tsx
@@ -151,7 +151,7 @@ export class Collapse extends PureComponent<CollapseProps, CollapseState> {
       minHeight,
       maxHeight: opened ? null : height,
       position: 'relative' as 'relative',
-      overflow: (!opened ? 'hidden' : 'initial') as 'hidden' | 'initial',
+      overflow: (opened ? null : 'hidden') as 'hidden' | null,
       transition: `ease-in-out ${animationDuration}ms max-height`,
     };
 

--- a/tests/__snapshots__/collapse.tsx.snap
+++ b/tests/__snapshots__/collapse.tsx.snap
@@ -72,7 +72,7 @@ exports[`Collapse should close to custom height 1`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "initial",
+        "overflow": null,
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }
@@ -200,7 +200,7 @@ exports[`Collapse should close to default height 1`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "initial",
+        "overflow": null,
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }
@@ -336,7 +336,7 @@ exports[`Collapse should match snapshot when expanded 1`] = `
     Object {
       "maxHeight": null,
       "minHeight": null,
-      "overflow": "initial",
+      "overflow": null,
       "position": "relative",
       "transition": "ease-in-out 200ms max-height",
     }
@@ -554,7 +554,7 @@ exports[`Collapse should open from custom height 4`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "initial",
+        "overflow": null,
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }
@@ -679,7 +679,7 @@ exports[`Collapse should open from default height 4`] = `
       Object {
         "maxHeight": null,
         "minHeight": null,
-        "overflow": "initial",
+        "overflow": null,
         "position": "relative",
         "transition": "ease-in-out 200ms max-height",
       }


### PR DESCRIPTION
Fixed overflow to be reset once the collapse is open, but this doesn't apply in IE because IE.