### PR TITLE
Button fixes and variables

### DIFF
--- a/examples/app.tsx
+++ b/examples/app.tsx
@@ -74,15 +74,35 @@ class App extends PureComponent<{}, AppState> {
           <h1>Example</h1>
 
           <Row>
-            <Column className="display-flex">
-              <Button block className="pill">
-                Pill
+            <Column>
+              <Button className="pill">Pill</Button>
+              <Button className="hollow">Hollow</Button>
+              <Button className="hollow pill">Hollow pill</Button>
+              <Button className="hollow primary">Hollow primary</Button>
+              <Button className="hollow pill secondary">
+                Hollow pill secondary
               </Button>
-              <Button block className="hollow">
-                Hollow
+            </Column>
+            <Column>
+              <Button className="small pill">Small pill</Button>
+              <Button className="small hollow">Small hollow</Button>
+              <Button className="small hollow pill">Small hollow pill</Button>
+              <Button className="small hollow primary">
+                Small hollow primary
               </Button>
-              <Button block className="hollow pill">
-                Hollow pill
+              <Button className="small hollow pill secondary">
+                Small hollow pill secondary
+              </Button>
+            </Column>
+            <Column>
+              <Button className="large pill">Large pill</Button>
+              <Button className="large hollow">Large hollow</Button>
+              <Button className="large hollow pill">Large hollow pill</Button>
+              <Button className="large hollow primary">
+                Large hollow primary
+              </Button>
+              <Button className="large hollow pill secondary">
+                Large hollow pill secondary
               </Button>
             </Column>
           </Row>

--- a/examples/app.tsx
+++ b/examples/app.tsx
@@ -87,7 +87,6 @@ class App extends PureComponent<{}, AppState> {
             </Column>
           </Row>
 
-
           <Row>
             <Column md={6}>
               <DabIpsum />

--- a/examples/app.tsx
+++ b/examples/app.tsx
@@ -74,6 +74,21 @@ class App extends PureComponent<{}, AppState> {
           <h1>Example</h1>
 
           <Row>
+            <Column className="display-flex">
+              <Button block className="pill">
+                Pill
+              </Button>
+              <Button block className="hollow">
+                Hollow
+              </Button>
+              <Button block className="hollow pill">
+                Hollow pill
+              </Button>
+            </Column>
+          </Row>
+
+
+          <Row>
             <Column md={6}>
               <DabIpsum />
             </Column>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.26",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.26",
+  "version": "0.10.0",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -43,7 +43,7 @@
     color: @background;
   }
 
-  &.hollow::after {
+  &.hollow {
     border-color: @background;
   }
 
@@ -127,19 +127,15 @@
 
   &.hollow {
     color: @background;
+    border: @button-border-width solid @background;
+    padding: @button-padding-vertical-base - @button-border-width @button-padding-horizontal-base - @button-border-width;
 
-    &::after {
-      content: '';
-      box-sizing: border-box;
-      pointer-events: none;
-      display: block;
-      position: absolute;
-      top: 0;
-      left: 0;
-      border: @button-border-width solid @background;
-      border-radius: @button-border-radius;
-      width: 100%;
-      height: 100%;
+    &.large {
+      padding: @button-padding-vertical-large - @button-border-width @button-padding-horizontal-large - @button-border-width;
+    }
+
+    &.small {
+      padding: @button-padding-vertical-small - @button-border-width @button-padding-horizontal-small - @button-border-width;
     }
 
     &:hover:not([disabled]):not(.disabled) {
@@ -149,10 +145,6 @@
 
   &.pill {
     border-radius: @button-border-radius-pill;
-
-    &::after {
-      border-radius: @button-border-radius-pill;
-    }
   }
 
   a {

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -130,16 +130,14 @@
       content: '';
       box-sizing: border-box;
       pointer-events: none;
-      display: block;
+      display: table;
       position: absolute;
       top: 0;
       left: 0;
       border: @button-border-width solid @background;
       border-radius: @border-radius-base;
-      // Fixes a Chrome rendering bug
-      transform: translate3d(0, 0, 0); // DO NOT CHANGE
-      width: 99.99%; // DO NOT CHANGE
-      height: 99.99%; // DO NOT CHANGE
+      width: 100%;
+      height: 100%;
     }
 
     &:hover:not([disabled]):not(.disabled) {

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -132,7 +132,7 @@
       content: '';
       box-sizing: border-box;
       pointer-events: none;
-      display: table;
+      display: block;
       position: absolute;
       top: 0;
       left: 0;

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -6,7 +6,7 @@
   cursor: pointer;
   background-color: transparent;
   transition: ease-in-out 0.2s background-color;
-  border-radius: @border-radius-base;
+  border-radius: @button-border-radius;
 
   &::before {
     content: '';
@@ -83,13 +83,15 @@
   }
 
   &.large {
-    font-size: @font-size-large;
-    padding: @padding-large / 2 @padding-large;
+    font-size: @font-size-button-large;
+    line-height: @line-height-button-large;
+    padding: @button-padding-large;
   }
 
   &.small {
-    font-size: @font-size-small;
-    padding: @padding-small / 2 @padding-small;
+    font-size: @font-size-button-small;
+    line-height: @line-height-button-small;
+    padding: @button-padding-small;
   }
 
   &.link {
@@ -135,7 +137,7 @@
       top: 0;
       left: 0;
       border: @button-border-width solid @background;
-      border-radius: @border-radius-base;
+      border-radius: @button-border-radius;
       width: 100%;
       height: 100%;
     }
@@ -146,10 +148,10 @@
   }
 
   &.pill {
-    border-radius: @padding-base * 2;
+    border-radius: @button-border-radius-pill;
 
     &::after {
-      border-radius: @padding-base * 2;
+      border-radius: @button-border-radius-pill;
     }
   }
 

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -85,13 +85,13 @@
   &.large {
     font-size: @font-size-button-large;
     line-height: @line-height-button-large;
-    padding: @button-padding-large;
+    padding: @button-padding-vertical-large @button-padding-horizontal-large;
   }
 
   &.small {
     font-size: @font-size-button-small;
     line-height: @line-height-button-small;
-    padding: @button-padding-small;
+    padding: @button-padding-vertical-small @button-padding-horizontal-small;
   }
 
   &.link {

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -128,14 +128,17 @@
   &.hollow {
     color: @background;
     border: @button-border-width solid @background;
-    padding: @button-padding-vertical-base - @button-border-width @button-padding-horizontal-base - @button-border-width;
+    padding: @button-padding-vertical-base - @button-border-width
+      @button-padding-horizontal-base - @button-border-width;
 
     &.large {
-      padding: @button-padding-vertical-large - @button-border-width @button-padding-horizontal-large - @button-border-width;
+      padding: @button-padding-vertical-large - @button-border-width
+      @button-padding-horizontal-large - @button-border-width;
     }
 
     &.small {
-      padding: @button-padding-vertical-small - @button-border-width @button-padding-horizontal-small - @button-border-width;
+      padding: @button-padding-vertical-small - @button-border-width
+      @button-padding-horizontal-small - @button-border-width;
     }
 
     &:hover:not([disabled]):not(.disabled) {

--- a/src/less/overrides.less
+++ b/src/less/overrides.less
@@ -102,9 +102,9 @@ pre {
 
 .button-overrides() {
   position: relative;
-  border-radius: @border-radius-base;
+  border-radius: @button-border-radius;
   border: @border-none;
-  padding: @padding-base / 2 @padding-base;
+  padding: @button-padding-base;
   font-weight: @font-weight-normal;
   font-family: @font-family-base;
   cursor: pointer;

--- a/src/less/overrides.less
+++ b/src/less/overrides.less
@@ -104,7 +104,7 @@ pre {
   position: relative;
   border-radius: @button-border-radius;
   border: @border-none;
-  padding: @button-padding-base;
+  padding: @button-padding-vertical-base @button-padding-horizontal-base;
   font-weight: @font-weight-normal;
   font-family: @font-family-base;
   cursor: pointer;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -111,6 +111,11 @@
 @button-text-color-light: @grey-lightest;
 @button-background-default: @grey-medium;
 @button-background-hollow: transparent;
+@button-border-radius: @border-radius-base;
+@button-border-radius-pill: 100px;
+@button-padding-base: @padding-base / 2 @padding-base;
+@button-padding-large: @padding-large / 2 @padding-large;
+@button-padding-small: @padding-small / 2 @padding-small;
 
 @speech-bubble-arrow-size: 10px;
 @speech-bubble-border-radius: 10px;
@@ -228,6 +233,10 @@
 
 @font-size-button: 1em;
 @line-height-button: 1.3em;
+@font-size-button-large: @font-size-large;
+@line-height-button-large: @line-height-button;
+@font-size-button-small: @font-size-small;
+@line-height-button-small: @line-height-button;
 
 @font-color-base: @grey-dark;
 @font-color-light: @grey-light;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -113,9 +113,12 @@
 @button-background-hollow: transparent;
 @button-border-radius: @border-radius-base;
 @button-border-radius-pill: 100px;
-@button-padding-base: @padding-base / 2 @padding-base;
-@button-padding-large: @padding-large / 2 @padding-large;
-@button-padding-small: @padding-small / 2 @padding-small;
+@button-padding-vertical-base: @padding-base / 2;
+@button-padding-vertical-large: @padding-large / 2;
+@button-padding-vertical-small: @padding-small / 2;
+@button-padding-horizontal-base: @padding-base;
+@button-padding-horizontal-large: @padding-large;
+@button-padding-horizontal-small: @padding-small;
 
 @speech-bubble-arrow-size: 10px;
 @speech-bubble-border-radius: 10px;

--- a/src/ts/components/forms/button.examples.md
+++ b/src/ts/components/forms/button.examples.md
@@ -110,7 +110,19 @@ You can then use your custom buttons by supplying the name you provided to the m
 @button-text-color-light: @grey-lightest;
 @button-background-default: @grey-medium;
 @button-background-hollow: transparent;
+@button-border-radius: @border-radius-base;
+@button-border-radius-pill: 100px;
+@button-padding-vertical-base: @padding-base / 2;
+@button-padding-vertical-large: @padding-large / 2;
+@button-padding-vertical-small: @padding-small / 2;
+@button-padding-horizontal-base: @padding-base;
+@button-padding-horizontal-large: @padding-large;
+@button-padding-horizontal-small: @padding-small;
 
 @font-size-button: 1em;
 @line-height-button: 1.3em;
+@font-size-button-large: @font-size-large;
+@line-height-button-large: @line-height-button;
+@font-size-button-small: @font-size-small;
+@line-height-button-small: @line-height-button;
 ```


### PR DESCRIPTION
Fixes rendering bug with pill style buttons (previous fix now breaks them).
Exposes additional button variables to prevent overriding styles manually.

A more permanent solution may be required if Chrome updates and the buttons end up rendering strangely again.

Before:

<img width="342" alt="Screen Shot 2019-04-05 at 12 11 13" src="https://user-images.githubusercontent.com/5850625/55623797-f1d00500-579b-11e9-92c3-6a9de10899e3.png">

After:

<img width="952" alt="Screen Shot 2019-04-05 at 12 10 39" src="https://user-images.githubusercontent.com/5850625/55623765-db29ae00-579b-11e9-8a79-ba7c37d0bade.png">
