### PR TITLE
Strip out internal StoreState to prevent it from showing up in projects

### DIFF
--- a/src/ts/store.tsx
+++ b/src/ts/store.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 
+/** @internal */
 export type ComponentType<P> =
   | React.ComponentClass<P>
   | React.StatelessComponent<P>;
 
+/** @internal */
 export type StoreState = Partial<{
   hasFixedNavBar: boolean;
   hasStickyFooter: boolean;
@@ -11,8 +13,10 @@ export type StoreState = Partial<{
   footerHeight: number;
 }>;
 
+/** @internal */
 export type StoreListener = (state: StoreState) => any;
 
+/** @internal */
 export class Store {
   private state: StoreState = {};
   private listeners: StoreListener[] = [];
@@ -55,4 +59,5 @@ export class Store {
   };
 }
 
+/** @internal */
 export default new Store();

--- a/src/ts/tsconfig.json
+++ b/src/ts/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "stripInternal": true,
     "sourceMap": true,
     "listFiles": true,
     "rootDir": "./",


### PR DESCRIPTION
Not sure if this is the best approach but we are finding that on our project `StoreState` is constantly imported from Roe rather than the project itself automatically, which can be really annoying.

I know we probably shouldn't be lazy and just make sure we import `StoreState` properly, but also surely Roe shouldn't output it as a definition - this is my attempt at the latter.