### PR TITLE
Update lifecycle methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/ts/components/app/root.tsx
+++ b/src/ts/components/app/root.tsx
@@ -27,9 +27,6 @@ export class AppRoot extends PureComponent<AppRootProps, AppRootState> {
     super(props);
 
     this.state = store.getState();
-  }
-
-  public componentWillMount() {
     this.unsubscribe = store.subscribe(
       ({ hasStickyFooter, hasFixedNavBar, navBarHeight, footerHeight }) => {
         this.setState({

--- a/src/ts/components/navigation/footer.tsx
+++ b/src/ts/components/navigation/footer.tsx
@@ -27,9 +27,10 @@ export class Footer extends PureComponent<FooterProps, {}> {
       Boolean(this.props.sticky || this.props.fixed) !==
       Boolean(prevProps.sticky || prevProps.fixed)
     ) {
-      this.notifyAppRoot(this.props);
       this.toggleResizeListeners(this.props);
     }
+
+    this.notifyAppRoot(this.props);
   }
 
   public componentWillUnmount() {

--- a/src/ts/components/navigation/footer.tsx
+++ b/src/ts/components/navigation/footer.tsx
@@ -22,13 +22,13 @@ export class Footer extends PureComponent<FooterProps, {}> {
     this.toggleResizeListeners(this.props);
   }
 
-  public componentWillUpdate(nextProps: FooterProps) {
+  public componentDidUpdate(prevProps: FooterProps) {
     if (
       Boolean(this.props.sticky || this.props.fixed) !==
-      Boolean(nextProps.sticky || nextProps.fixed)
+      Boolean(prevProps.sticky || prevProps.fixed)
     ) {
-      this.notifyAppRoot(nextProps);
-      this.toggleResizeListeners(nextProps);
+      this.notifyAppRoot(this.props);
+      this.toggleResizeListeners(this.props);
     }
   }
 

--- a/src/ts/components/navigation/nav-bar.tsx
+++ b/src/ts/components/navigation/nav-bar.tsx
@@ -56,9 +56,10 @@ export class NavBar extends PureComponent<NavBarProps, NavBarState> {
       Boolean(this.props.fixed) !== Boolean(prevProps.fixed) ||
       Boolean(this.props.shy) !== Boolean(prevProps.shy)
     ) {
-      this.notifyAppRoot(this.props);
       this.toggleResizeListeners(this.props);
     }
+
+    this.notifyAppRoot(this.props);
   }
 
   public componentWillUnmount() {

--- a/src/ts/components/navigation/nav-bar.tsx
+++ b/src/ts/components/navigation/nav-bar.tsx
@@ -47,17 +47,17 @@ export class NavBar extends PureComponent<NavBarProps, NavBarState> {
     this.mountTime = new Date().getTime();
   }
 
-  public componentWillUpdate(nextProps: NavBarProps) {
-    if (Boolean(this.props.shy) !== Boolean(nextProps.shy)) {
-      this.toggleShyListeners(nextProps);
+  public componentDidUpdate(prevProps: NavBarProps) {
+    if (Boolean(this.props.shy) !== Boolean(prevProps.shy)) {
+      this.toggleShyListeners(this.props);
     }
 
     if (
-      Boolean(this.props.fixed) !== Boolean(nextProps.fixed) ||
-      Boolean(this.props.shy) !== Boolean(nextProps.shy)
+      Boolean(this.props.fixed) !== Boolean(prevProps.fixed) ||
+      Boolean(this.props.shy) !== Boolean(prevProps.shy)
     ) {
-      this.notifyAppRoot(nextProps);
-      this.toggleResizeListeners(nextProps);
+      this.notifyAppRoot(this.props);
+      this.toggleResizeListeners(this.props);
     }
   }
 

--- a/tests/footer.tsx
+++ b/tests/footer.tsx
@@ -67,7 +67,7 @@ describe('Footer', () => {
 
       expect(window.removeEventListener).toHaveBeenCalledTimes(0);
       (window.removeEventListener as jest.Mock<any>).mockClear();
-      expect(store.setState).toHaveBeenCalledTimes(0);
+      expect(store.setState).toHaveBeenCalledTimes(1);
       (store.setState as jest.Mock<any>).mockClear();
 
       instance.setProps({ sticky: true });
@@ -201,7 +201,7 @@ describe('Footer', () => {
 
       expect(window.removeEventListener).toHaveBeenCalledTimes(0);
       (window.removeEventListener as jest.Mock<any>).mockClear();
-      expect(store.setState).toHaveBeenCalledTimes(0);
+      expect(store.setState).toHaveBeenCalledTimes(1);
       (store.setState as jest.Mock<any>).mockClear();
 
       instance.setProps({ fixed: true });

--- a/tests/nav-bar.tsx
+++ b/tests/nav-bar.tsx
@@ -92,7 +92,7 @@ describe('NavBar', () => {
 
     expect(window.removeEventListener).toHaveBeenCalledTimes(0);
     (window.removeEventListener as jest.Mock<any>).mockClear();
-    expect(store.setState).toHaveBeenCalledTimes(0);
+    expect(store.setState).toHaveBeenCalledTimes(1);
     (store.setState as jest.Mock<any>).mockClear();
 
     instance.setProps({ shy: true });


### PR DESCRIPTION
Swap deprecated `willUpdate` methods for `didUpdate`.
Move  app root`willMount` subscriber to constructor.
Ensure footer and nav-bar always notify the app root about changes (for size).