### PR TITLE
Fix typos in spacing top auto classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/less/spacing.less
+++ b/src/less/spacing.less
@@ -82,7 +82,7 @@
   }
 
   .@{prefix}-@{style}-top-auto {
-    .spacing-directional-styles(@style, 0, toauto);
+    .spacing-directional-styles(@style, auto, top);
   }
 
   .@{prefix}-@{style}-top-base {
@@ -223,7 +223,7 @@
     }
 
     .@{style}-top-auto {
-      .spacing-directional-styles(@style, 0, toauto);
+      .spacing-directional-styles(@style, auto, top);
     }
 
     .@{style}-top-base {

--- a/src/less/spacing.less
+++ b/src/less/spacing.less
@@ -102,7 +102,7 @@
   }
 
   .@{prefix}-@{style}-right-auto {
-    .spacing-directional-styles(@style, 0, righauto);
+    .spacing-directional-styles(@style, auto, right);
   }
 
   .@{prefix}-@{style}-right-base {
@@ -122,7 +122,7 @@
   }
 
   .@{prefix}-@{style}-bottom-auto {
-    .spacing-directional-styles(@style, 0, bottoauto);
+    .spacing-directional-styles(@style, auto, bottom);
   }
 
   .@{prefix}-@{style}-bottom-base {
@@ -142,7 +142,7 @@
   }
 
   .@{prefix}-@{style}-left-auto {
-    .spacing-directional-styles(@style, 0, lefauto);
+    .spacing-directional-styles(@style, auto, left);
   }
 
   .@{prefix}-@{style}-left-base {
@@ -247,7 +247,7 @@
     }
 
     .@{style}-right-auto {
-      .spacing-directional-styles(@style, 0, righauto);
+      .spacing-directional-styles(@style, auto, right);
     }
 
     .@{style}-right-small {
@@ -263,7 +263,7 @@
     }
 
     .@{style}-bottom-auto {
-      .spacing-directional-styles(@style, 0, bottoauto);
+      .spacing-directional-styles(@style, auto, bottom);
     }
 
     .@{style}-bottom-base {
@@ -283,7 +283,7 @@
     }
 
     .@{style}-left-auto {
-      .spacing-directional-styles(@style, 0, lefauto);
+      .spacing-directional-styles(@style, auto, left);
     }
 
     .@{style}-left-base {


### PR DESCRIPTION
This doesn't cause errors, but does make these classes not work.