### PR TITLE
Footer and NavBar ResizeObserver

### DIFF
--- a/examples/app.tsx
+++ b/examples/app.tsx
@@ -321,6 +321,10 @@ class App extends PureComponent<{}, AppState> {
         <Footer fixed>
           <Container>
             <p>Footer</p>
+            <p>
+              This is a really long sentence that should wrap onto multiple
+              lines when the page is resized.
+            </p>
           </Container>
         </Footer>
       </AppRoot>

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,6 +344,11 @@
         }
       }
     },
+    "@juggle/resize-observer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.2.0.tgz",
+      "integrity": "sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg=="
+    },
     "@types/cheerio": {
       "version": "0.22.8",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "homepage": "https://github.com/dabapps/roe#readme",
   "dependencies": {
+    "@juggle/resize-observer": "^3.2.0",
     "@types/classnames": "^2.2.0",
     "@types/cookie": "^0.3.1",
     "@types/random-seed": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "test-dist-react-16": "npm i @types/react@16.4.7 @types/react-dom@16.0.6 --no-save && tsc --project 'tsconfig.json' --noEmit && npm run dist",
     "test-dist-react-15": "npm i @types/react@15.6.18 @types/react-dom@15.5.7 --no-save && tsc --project 'tsconfig.json' --noEmit && npm run dist",
     "test-dist": "npm run test-dist-react-15 && npm run test-dist-react-16",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
     "tests": "jest",
-    "test": "npm run prettier-check && npm run lint && npm run tests -- --coverage --runInBand && npm run test-dist",
+    "test": "npm run prettier-check && npm run lint && npm run typecheck && npm run tests -- --coverage --runInBand && npm run test-dist",
     "budo": "budo src/less/index.less examples/index.tsx --live -- -t node-lessify -p [tsify -p tsconfig.examples.json]",
     "prepublishOnly": "./scripts/dist"
   },

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     },
     "testRegex": "tests/.+\\.(ts|tsx|js|jsx)$",
     "testPathIgnorePatterns": [
+      "<rootDir>/tests/__mocks__/",
       "<rootDir>/tests/helpers/"
     ],
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/ts/components/navigation/footer.tsx
+++ b/src/ts/components/navigation/footer.tsx
@@ -1,8 +1,8 @@
+import { ResizeObserver } from '@juggle/resize-observer';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import { HTMLProps, PureComponent } from 'react';
 import * as ReactDOM from 'react-dom';
-import { ResizeObserver } from '@juggle/resize-observer';
 import store from '../../store';
 import { ComponentProps } from '../../types';
 
@@ -80,7 +80,10 @@ export class Footer extends PureComponent<FooterProps, {}> {
     const { sticky, fixed } = props;
 
     if (sticky || fixed) {
-      this.resizeObserver.observe(ReactDOM.findDOMNode(this));
+      const element = ReactDOM.findDOMNode(this);
+      if (element instanceof HTMLElement) {
+        this.resizeObserver.observe(element);
+      }
     } else {
       this.resizeObserver.disconnect();
     }

--- a/src/ts/components/navigation/footer.tsx
+++ b/src/ts/components/navigation/footer.tsx
@@ -2,6 +2,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { HTMLProps, PureComponent } from 'react';
 import * as ReactDOM from 'react-dom';
+import { ResizeObserver } from '@juggle/resize-observer';
 import store from '../../store';
 import { ComponentProps } from '../../types';
 
@@ -34,7 +35,7 @@ export class Footer extends PureComponent<FooterProps, {}> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.updateAppRoot);
+    this.resizeObserver.disconnect();
     this.notifyAppRoot({ sticky: false });
   }
 
@@ -79,11 +80,14 @@ export class Footer extends PureComponent<FooterProps, {}> {
     const { sticky, fixed } = props;
 
     if (sticky || fixed) {
-      window.addEventListener('resize', this.updateAppRoot);
+      this.resizeObserver.observe(ReactDOM.findDOMNode(this));
     } else {
-      window.removeEventListener('resize', this.updateAppRoot);
+      this.resizeObserver.disconnect();
     }
   }
+
+  // tslint:disable-next-line:member-ordering
+  private resizeObserver = new ResizeObserver(this.updateAppRoot);
 }
 
 export default Footer;

--- a/src/ts/components/navigation/nav-bar.tsx
+++ b/src/ts/components/navigation/nav-bar.tsx
@@ -1,8 +1,8 @@
+import { ResizeObserver } from '@juggle/resize-observer';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import { HTMLProps, PureComponent } from 'react';
 import * as ReactDOM from 'react-dom';
-import { ResizeObserver } from '@juggle/resize-observer';
 import store from '../../store';
 import { ComponentProps } from '../../types';
 import { getScrollOffset } from '../../utils';
@@ -120,7 +120,10 @@ export class NavBar extends PureComponent<NavBarProps, NavBarState> {
     const { fixed, shy } = props;
 
     if (fixed || shy) {
-      this.resizeObserver.observe(ReactDOM.findDOMNode(this));
+      const element = ReactDOM.findDOMNode(this);
+      if (element instanceof HTMLElement) {
+        this.resizeObserver.observe(element);
+      }
     } else {
       this.resizeObserver.disconnect();
     }

--- a/src/ts/components/navigation/nav-bar.tsx
+++ b/src/ts/components/navigation/nav-bar.tsx
@@ -2,6 +2,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { HTMLProps, PureComponent } from 'react';
 import * as ReactDOM from 'react-dom';
+import { ResizeObserver } from '@juggle/resize-observer';
 import store from '../../store';
 import { ComponentProps } from '../../types';
 import { getScrollOffset } from '../../utils';
@@ -65,7 +66,7 @@ export class NavBar extends PureComponent<NavBarProps, NavBarState> {
   public componentWillUnmount() {
     window.removeEventListener('scroll', this.hideOrShowNavBar);
     window.removeEventListener('resize', this.hideOrShowNavBar);
-    window.removeEventListener('resize', this.updateAppRoot);
+    this.resizeObserver.disconnect();
     this.notifyAppRoot({ fixed: false });
   }
 
@@ -119,9 +120,9 @@ export class NavBar extends PureComponent<NavBarProps, NavBarState> {
     const { fixed, shy } = props;
 
     if (fixed || shy) {
-      window.addEventListener('resize', this.updateAppRoot);
+      this.resizeObserver.observe(ReactDOM.findDOMNode(this));
     } else {
-      window.removeEventListener('resize', this.updateAppRoot);
+      this.resizeObserver.disconnect();
     }
   }
 
@@ -168,6 +169,9 @@ export class NavBar extends PureComponent<NavBarProps, NavBarState> {
       }
     }
   };
+
+  // tslint:disable-next-line:member-ordering
+  private resizeObserver = new ResizeObserver(this.updateAppRoot);
 }
 
 export default NavBar;

--- a/tests/__mocks__/@juggle/resize-observer.ts
+++ b/tests/__mocks__/@juggle/resize-observer.ts
@@ -1,0 +1,16 @@
+export const mockConstructor = jest.fn();
+
+export const mockObserve = jest.fn();
+export const mockUnobserve = jest.fn();
+export const mockDisconnect = jest.fn();
+
+class MockResizeObserver {
+  public observe = mockObserve;
+  public unobserve = mockUnobserve;
+  public disconnect = mockDisconnect;
+  public constructor(callback: () => void) {
+    mockConstructor(callback);
+  }
+}
+
+export { MockResizeObserver as ResizeObserver };

--- a/tests/footer.tsx
+++ b/tests/footer.tsx
@@ -57,6 +57,14 @@ describe('Footer', () => {
       expect(tree).toMatchSnapshot();
     });
 
+    it('should observe the element when no element is found', () => {
+      (ReactDOM.findDOMNode as jest.Mock<any>).mockReturnValue(null);
+
+      enzyme.mount(<Footer fixed />);
+
+      expect(mockObserve).toHaveBeenCalledTimes(0);
+    });
+
     it('should toggle sticky listeners and update the app root on mount and props change', () => {
       const instance = enzyme.mount(<Footer />);
 

--- a/tests/footer.tsx
+++ b/tests/footer.tsx
@@ -57,7 +57,7 @@ describe('Footer', () => {
       expect(tree).toMatchSnapshot();
     });
 
-    it('should observe the element when no element is found', () => {
+    it('should not observe the element when no element is found', () => {
       (ReactDOM.findDOMNode as jest.Mock<any>).mockReturnValue(null);
 
       enzyme.mount(<Footer fixed />);

--- a/tests/nav-bar.tsx
+++ b/tests/nav-bar.tsx
@@ -93,6 +93,14 @@ describe('NavBar', () => {
     expect(instance).toMatchSnapshot();
   });
 
+  it('should observe the element when no element is found', () => {
+    (ReactDOM.findDOMNode as jest.Mock<any>).mockReturnValue(null);
+
+    enzyme.mount(<NavBar fixed />);
+
+    expect(mockObserve).toHaveBeenCalledTimes(0);
+  });
+
   it('should toggle shy listeners and update the app root on mount and props change', () => {
     const instance = enzyme.mount(<NavBar />);
 

--- a/tests/nav-bar.tsx
+++ b/tests/nav-bar.tsx
@@ -93,7 +93,7 @@ describe('NavBar', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should observe the element when no element is found', () => {
+  it('should not observe the element when no element is found', () => {
     (ReactDOM.findDOMNode as jest.Mock<any>).mockReturnValue(null);
 
     enzyme.mount(<NavBar fixed />);


### PR DESCRIPTION
Instead of listening to window resize events we now observe the elements themselves, meaning that when the content (and even styles) of the element changes, the AppRoot will be notified.

This should be backward compatible, and so will be a patch version.