### PR TITLE
Set optional max age for cookie banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabapps/roe",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/ts/components/banners/cookie-banner.tsx
+++ b/src/ts/components/banners/cookie-banner.tsx
@@ -24,7 +24,7 @@ export type CookieBannerProps = {
    */
   position?: 'top' | 'bottom';
   /**
-   * Sets maximum age for the cookie in milliseconds
+   * Sets maximum age for the cookie in seconds
    * @default 60 * 60 * 24 * 365
    */
   maxAge?: number;
@@ -36,7 +36,7 @@ export type CookieBannerProps = {
  * which you can then apply as an onClick prop to an element of your choice.
  */
 
-const A_YEAR_IN_MS = 60 * 60 * 24 * 365;
+const A_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 
 const CookieBanner = (props: CookieBannerProps) => {
   const [dismissed, setDismissed] = React.useState(
@@ -45,7 +45,7 @@ const CookieBanner = (props: CookieBannerProps) => {
 
   const setCookie = () => {
     document.cookie = cookie.serialize('cookies-accepted', 'true', {
-      maxAge: props.maxAge || A_YEAR_IN_MS,
+      maxAge: props.maxAge || A_YEAR_IN_SECONDS,
     });
     setDismissed(true);
   };

--- a/src/ts/components/banners/cookie-banner.tsx
+++ b/src/ts/components/banners/cookie-banner.tsx
@@ -23,6 +23,11 @@ export type CookieBannerProps = {
    * @default 'bottom'
    */
   position?: 'top' | 'bottom';
+  /**
+   * Sets maximum age for the cookie in milliseconds
+   * @default 60 * 60 * 24 * 365
+   */
+  maxAge?: number;
 } & OptionalComponentPropAndHTMLAttributes;
 
 /**
@@ -30,13 +35,18 @@ export type CookieBannerProps = {
  * This component takes a render prop, which can be a component or function, that is passed a dismiss prop
  * which you can then apply as an onClick prop to an element of your choice.
  */
+
+const A_YEAR_IN_MS = 60 * 60 * 24 * 365;
+
 const CookieBanner = (props: CookieBannerProps) => {
   const [dismissed, setDismissed] = React.useState(
     Boolean(cookie.parse(document.cookie)['cookies-accepted'])
   );
 
   const setCookie = () => {
-    document.cookie = cookie.serialize('cookies-accepted', 'true');
+    document.cookie = cookie.serialize('cookies-accepted', 'true', {
+      maxAge: props.maxAge || A_YEAR_IN_MS,
+    });
     setDismissed(true);
   };
 


### PR DESCRIPTION
Note: Planning to publish a patch version `0.13.1`

- Set optional `maxAge` for cookie banner
- Default to 1 year
- Previously it defaulted to `session` (on browser close - I think may be wrong)

## Docs
<img width="404" alt="Screenshot 2021-04-22 at 12 25 26" src="https://user-images.githubusercontent.com/7873802/115710911-d1674900-a36a-11eb-845d-cdf0cddc4225.png">

## View (no changes)
<img width="520" alt="Screenshot 2021-04-22 at 12 26 31" src="https://user-images.githubusercontent.com/7873802/115710916-d1ffdf80-a36a-11eb-8d6c-f392f5604bcd.png">

## Example (set to 2 years)

`maxAge: 60 * 60 * 24 * 365 * 2`

<img width="758" alt="Screenshot 2021-04-22 at 12 27 05" src="https://user-images.githubusercontent.com/7873802/115710919-d2987600-a36a-11eb-8d2c-ebaf76be1811.png">
