### PR TITLE
Update button types

### DIFF
--- a/src/ts/components/forms/button.tsx
+++ b/src/ts/components/forms/button.tsx
@@ -16,6 +16,10 @@ export type ButtonProps = {
    * Make the button small
    */
   small?: boolean;
+  /**
+   * Add link to button
+   */
+  href?: string;
 } & React.ButtonHTMLAttributes<HTMLElement> &
   OptionalComponentPropAndHTMLAttributes;
 


### PR DESCRIPTION
Fix missing `href` property for the button when `component` props set to `a` tag.

Note: I plan to release this as a patch version `v0.13.2`