### PR TITLE
Specify cookie for entire subdomain rather than specific subpath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabapps/roe",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/roe",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A collection of React components, styles, mixins, and atomic CSS classes to aid with the development of web applications.",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/ts/components/banners/cookie-banner.tsx
+++ b/src/ts/components/banners/cookie-banner.tsx
@@ -46,6 +46,7 @@ const CookieBanner = (props: CookieBannerProps) => {
   const setCookie = () => {
     document.cookie = cookie.serialize('cookies-accepted', 'true', {
       maxAge: props.maxAge || A_YEAR_IN_SECONDS,
+      path: '/'
     });
     setDismissed(true);
   };

--- a/src/ts/components/banners/cookie-banner.tsx
+++ b/src/ts/components/banners/cookie-banner.tsx
@@ -46,7 +46,7 @@ const CookieBanner = (props: CookieBannerProps) => {
   const setCookie = () => {
     document.cookie = cookie.serialize('cookies-accepted', 'true', {
       maxAge: props.maxAge || A_YEAR_IN_SECONDS,
-      path: '/'
+      path: '/',
     });
     setDismissed(true);
   };


### PR DESCRIPTION
This should avoid the user to needing accepting the cookie for one sub-path after accepting the cookie for another sub-path or domain.

For example:
Accepting cookie for `/example` should still work for `/` and `example-2`.

Intended to the publish this as path version `v0.13.2`